### PR TITLE
セッション3.3におけるStateObjectの初期化方法を修正

### DIFF
--- a/GitHubClient/GitHubClientApp.swift
+++ b/GitHubClient/GitHubClientApp.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct GitHubClientApp: App {
     var body: some Scene {
         WindowGroup {
-            RepoListView(viewModel: RepoListViewModel())
+            RepoListView(repoRepository: RepoDataRepository())
         }
     }
 }

--- a/GitHubClient/Views/RepoListView.swift
+++ b/GitHubClient/Views/RepoListView.swift
@@ -3,8 +3,8 @@ import SwiftUI
 struct RepoListView: View {
     @StateObject private var viewModel: RepoListViewModel
 
-    init(viewModel: RepoListViewModel) {
-        _viewModel = StateObject(wrappedValue: viewModel)
+    init(repoRepository: RepoRepository) {
+        _viewModel = StateObject(wrappedValue: RepoListViewModel(repoRepository: repoRepository))
     }
 
     var body: some View {
@@ -58,31 +58,25 @@ struct RepoListView_Previews: PreviewProvider {
     static var previews: some View {
         Group {
             RepoListView(
-                viewModel: RepoListViewModel(
-                    repoRepository: MockRepoRepository(
-                        repos: [
-                            .mock1, .mock2, .mock3, .mock4, .mock5
-                        ]
-                    )
+                repoRepository: MockRepoRepository(
+                    repos: [
+                        .mock1, .mock2, .mock3, .mock4, .mock5
+                    ]
                 )
             )
             .previewDisplayName("Default")
 
             RepoListView(
-                viewModel: RepoListViewModel(
-                    repoRepository: MockRepoRepository(
-                        repos: []
-                    )
+                repoRepository: MockRepoRepository(
+                    repos: []
                 )
             )
             .previewDisplayName("Empty")
 
             RepoListView(
-                viewModel: RepoListViewModel(
-                    repoRepository: MockRepoRepository(
-                        repos: [],
-                        error: DummyError()
-                    )
+                repoRepository: MockRepoRepository(
+                    repos: [],
+                    error: DummyError()
                 )
             )
             .previewDisplayName("Error")


### PR DESCRIPTION
## 背景
公式ドキュメントにて、引数がある場合のStateObjectの初期化方法についての記述が追加されました。
https://developer.apple.com/documentation/swiftui/stateobject#Initialize-state-objects-using-external-data

上記ドキュメントでは、「StateObjectのinitializerを最初に呼び出すときだけStateObjectに渡されたautoclosureが実行される」とあります。

セクション3.3では、外部で初期化されたViewModelをViewのinitializer引数として受け取り、そのままStateObjectのautoclosureへ渡して初期化してしまっていました。これではViewModelのライフタイムがViewのライフサイクルと連動しません、StateObjectに渡すautoclosureの中でViewModelを初期化する必要があります。

## 変更点

- ViewModelではなく、そのViewModelの初期化に必要な `RepoRepository` をViewのinitializerで受け取るようにし、StateObjectのautoclosure内でViewModelを初期化するように修正

## 確認手順

- [ ] アプリ起動後、Repository一覧が適切に表示される
- [ ] Previewsに各状態でのRepoListViewが適切に表示される
- [ ] READMEが適切に更新されている
